### PR TITLE
hotfix: comparing wrong branches(dev, release and main)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,11 +19,11 @@ jobs:
       - name: Prepare Docker Image Tag
         id: prep
         run: |
-          if [[ ${{ github.ref }} == refs/heads/dev ]]; then
+          if [[ ${{ github.ref }} == refs/heads/develop_st/2.13.x ]]; then
             TAG=$(git rev-parse --short=8 ${{ github.sha }})
-          elif [[ ${{ github.ref }} == refs/heads/release/* ]]; then
+          elif [[ ${{ github.ref }} == refs/heads/release_st/* ]]; then
             TAG=$(echo ${{ github.ref }} | cut -d '/' -f 4)
-          elif [[ ${{ github.ref }} == refs/heads/main ]]; then
+          elif [[ ${{ github.ref }} == refs/heads/master_st ]]; then
             TAG=${{ 'latest' }}
           fi
           echo ::set-output name=image_tag::${TAG}


### PR DESCRIPTION
Armar un Pull Request bien detallado ayuda a que sea facil de entender para todos.

## Tarea de Origen

Link:

## Descripcion

Arreglo de la Integración Continua para generar la imágen Docker de este repositorio al momento de mergear a la rama develop.  
Estábamos comparando contra las ramas incorrectas para implementar el flujo, las ramas deberían ser:
- **develop_st/2.13.x**, se estaba usando develop
- **release_st**, se estaba usando release
- **master_st**, se estaba usando master
## Bug fixes

- Arreglo del CI usando las ramas correctas.
- Agrega un caso por defecto para utilizar el último hash commit.
